### PR TITLE
Fix radio button group to set the value of the selected button

### DIFF
--- a/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
+++ b/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
@@ -251,7 +251,7 @@ public final class RadioButton extends RbCbSelector {
     }
 
     @Override
-    public void updateModel(FacesContext context) {
+    public void updateModel(final FacesContext context) {
         if (Objects.equals(getSelected(getName()), getValue())) {
             super.updateModel(context);
         }

--- a/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
+++ b/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
@@ -20,6 +20,7 @@ import com.sun.faces.annotation.Property;
 import java.util.Map;
 import jakarta.el.ValueExpression;
 import jakarta.faces.context.FacesContext;
+import java.util.Objects;
 
 /**
  * <p>
@@ -246,6 +247,13 @@ public final class RadioButton extends RbCbSelector {
             return rm.get(name);
         } else {
             return null;
+        }
+    }
+
+    @Override
+    public void updateModel(FacesContext context) {
+        if (Objects.equals(getSelected(getName()), getValue())) {
+            super.updateModel(context);
         }
     }
 

--- a/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
+++ b/woodstock-webui-jsf/src/main/java/com/sun/webui/jsf/component/RadioButton.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2023 Contributors to the Eclipse Foundation.
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the


### PR DESCRIPTION
Unselected buttons don't set the value. 
Before, unselected buttons covered the selected value if they came later  in the view than the selected button.

Partially fixes https://github.com/eclipse-ee4j/glassfish/issues/24434 - when selecting radio buttons, unselected buttons don't overwrite the selected value.