### PR TITLE
Prepare next development cycle for 6.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2020 Payara Services Ltd.
 
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>6.0.2-SNAPSHOT</version>
+    <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>6.0.1</version>
+    <version>6.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.glassfish.woodstock</groupId>
     <artifactId>woodstock-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.1</version>
     <packaging>pom</packaging>
 
     <name>Woodstock Parent</name>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-dt/pom.xml
+++ b/woodstock-dt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-dt</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-example/pom.xml
+++ b/woodstock-example/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-example</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/dojo/pom.xml
+++ b/woodstock-external/dojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock.external</groupId>
         <artifactId>woodstock-external</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dojo</artifactId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-external/pom.xml
+++ b/woodstock-external/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.woodstock.external</groupId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf-suntheme/pom.xml
+++ b/woodstock-webui-jsf-suntheme/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf-suntheme</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>

--- a/woodstock-webui-jsf/pom.xml
+++ b/woodstock-webui-jsf/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
+    Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation. All rights reserved.
     Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.glassfish.woodstock</groupId>
         <artifactId>woodstock-parent</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>woodstock-webui-jsf</artifactId>


### PR DESCRIPTION
For the upcoming changes
- jakarta.el:jakarta.el-api 5.0.1 -> 6.0.0
- jakarta.enterprise:jakarta.enterprise.cdi-api 4.0.1 -> 4.1.0
- jakarta.faces:jakarta.faces-api 4.0.1 -> 4.1.0
- jakarta.servlet:jakarta.servlet-api 6.0.0 -> 6.1.0
- jakarta.servlet.jsp:jakarta.servlet.jsp-api 3.1.0 -> 4.0.0
- org.glassfish:jakarta.faces 4.0.0 -> 4.1.0

I propose to update project to 6.1.

- closes #1440 