### PR TITLE
Drop exclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,12 +277,6 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <version>8.18</version>
-                            <exclusions>
-                                <exclusion>
-                                    <groupId>com.sun</groupId>
-                                    <artifactId>tools</artifactId>
-                                </exclusion>
-                            </exclusions>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
CS 8.8 was the last one to depend on `tools.jar`:
- https://github.com/checkstyle/checkstyle/issues/5431