### PR TITLE
Improve error messages on deploying apps over upload size limit in Admin Console

### DIFF
--- a/woodstock-webui-jsf-suntheme/src/main/resources/messages/messages.properties
+++ b/woodstock-webui-jsf-suntheme/src/main/resources/messages/messages.properties
@@ -1,4 +1,5 @@
 #
+# Copyright (c) 2024 Contributors to the Eclipse Foundation.
 # Copyright (c) 2007, 2019 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -548,7 +549,7 @@ tree.skipTagAltText=Jump Over Tree Navigation Area.
 
 # File Upload messages
 FileUpload.noFile=No file was uploaded
-Upload.error=The specified file exceeds the maximum allowable size of {0} Mb
+Upload.error=The specified file exceeds the maximum allowable size of {0} bytes
 
 # Version Page resources
 Version.closeButton=Close


### PR DESCRIPTION
* Follow-up: https://github.com/eclipse-ee4j/glassfish/pull/25284
* After fixed:  


![4-error-fixed-2](https://github.com/user-attachments/assets/ee24f441-f9dd-45fc-a82a-1b1a39fb0372)

Signed-off-by: dmiya3 <miyazaki.daiki@fujitsu.com>